### PR TITLE
feat: add controlled game start with start screen overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Snake Game</title>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
     <div class="game-container">
-        <div class="game-header">
-            <h1>Snake Game</h1>
-            <div class="score-container">
-                <span>Score: </span>
-                <span id="score">0</span>
-            </div>
+      <div class="game-header">
+        <h1>Snake Game</h1>
+        <div class="score-container">
+          <span>Score: </span>
+          <span id="score">0</span>
         </div>
-        
-        <div class="game-board" id="game-board"></div>
-        
-        <div class="controls">
-            <div class="controls-row">
-                <button id="up-btn">↑</button>
-            </div>
-            <div class="controls-row">
-                <button id="left-btn">←</button>
-                <button id="down-btn">↓</button>
-                <button id="right-btn">→</button>
-            </div>
-        </div>
+      </div>
 
-        <div class="game-over" id="game-over">
-            <h2>Game Over!</h2>
-            <p>Your score: <span id="final-score">0</span></p>
-            <button id="restart-btn">Play Again</button>
+      <div id="start-screen" class="overlay show">
+        <p>Press Space or click to start the game</p>
+      </div>
+
+      <div class="game-board" id="game-board"></div>
+
+      <div class="controls">
+        <div class="controls-row">
+          <button id="up-btn">↑</button>
         </div>
+        <div class="controls-row">
+          <button id="left-btn">←</button>
+          <button id="down-btn">↓</button>
+          <button id="right-btn">→</button>
+        </div>
+      </div>
+
+      <div class="game-over" id="game-over">
+        <h2>Game Over!</h2>
+        <p>Your score: <span id="final-score">0</span></p>
+        <button id="restart-btn">Play Again</button>
+      </div>
     </div>
-    
+
     <script src="script.js"></script>
-</body>
+  </body>
 </html>
+

--- a/script.js
+++ b/script.js
@@ -1,332 +1,376 @@
-document.addEventListener('DOMContentLoaded', () => {
-    // Game settings
-    const GRID_SIZE = 20;
-    const GAME_SPEED = 150;
-    const INITIAL_SNAKE_LENGTH = 3;
-    
-    // Game elements
-    const gameBoard = document.getElementById('game-board');
-    const scoreElement = document.getElementById('score');
-    const finalScoreElement = document.getElementById('final-score');
-    const gameOverElement = document.getElementById('game-over');
-    const restartBtn = document.getElementById('restart-btn');
-    
-    // Control buttons
-    const upBtn = document.getElementById('up-btn');
-    const downBtn = document.getElementById('down-btn');
-    const leftBtn = document.getElementById('left-btn');
-    const rightBtn = document.getElementById('right-btn');
-    
-    // Game state
-    let snake = [];
-    let food = {};
-    let direction = 'right';
-    let nextDirection = 'right';
-    let score = 0;
-    let gameInterval;
-    let isGameOver = false;
-    
-    // Initialize the game
-    function initGame() {
-        // Reset game state
-        snake = [];
-        direction = 'right';
-        nextDirection = 'right';
-        score = 0;
-        isGameOver = false;
-        
-        // Clear the game board
-        gameBoard.innerHTML = '';
-        gameBoard.style.gridTemplateColumns = `repeat(${GRID_SIZE}, 1fr)`;
-        gameBoard.style.gridTemplateRows = `repeat(${GRID_SIZE}, 1fr)`;
-        
-        // Create the grid cells
-        for (let i = 0; i < GRID_SIZE * GRID_SIZE; i++) {
-            const cell = document.createElement('div');
-            cell.classList.add('cell');
-            gameBoard.appendChild(cell);
-        }
-        
-        // Initialize the snake
-        const startX = Math.floor(GRID_SIZE / 2);
-        const startY = Math.floor(GRID_SIZE / 2);
-        
-        for (let i = 0; i < INITIAL_SNAKE_LENGTH; i++) {
-            snake.push({
-                x: startX - i,
-                y: startY
-            });
-        }
-        
-        // Draw the initial snake
-        drawSnake();
-        
-        // Place the first food
-        placeFood();
-        
-        // Update the score display
-        updateScore();
-        
-        // Hide game over screen
-        gameOverElement.classList.remove('show');
-        
-        // Start the game loop
-        if (gameInterval) clearInterval(gameInterval);
-        gameInterval = setInterval(gameLoop, GAME_SPEED);
+document.addEventListener("DOMContentLoaded", () => {
+  // Game settings
+  const GRID_SIZE = 20;
+  const GAME_SPEED = 150;
+  const INITIAL_SNAKE_LENGTH = 3;
+
+  // Game elements
+  const gameBoard = document.getElementById("game-board");
+  const scoreElement = document.getElementById("score");
+  const finalScoreElement = document.getElementById("final-score");
+  const gameOverElement = document.getElementById("game-over");
+  const restartBtn = document.getElementById("restart-btn");
+  const startScreen = document.getElementById("start-screen");
+
+  // Control buttons
+  const upBtn = document.getElementById("up-btn");
+  const downBtn = document.getElementById("down-btn");
+  const leftBtn = document.getElementById("left-btn");
+  const rightBtn = document.getElementById("right-btn");
+
+  // Game state
+  let snake = [];
+  let food = {};
+  let direction = "right";
+  let nextDirection = "right";
+  let score = 0;
+  let gameInterval;
+  let isGameOver = false;
+  let isGameRunning = false;
+
+  // Start game
+  function startGame() {
+    if (!isGameRunning) {
+      isGameRunning = true;
+      startScreen.classList.remove("show");
+
+      // Initialize the game
+      initGame();
     }
-    
-    // Main game loop
-    function gameLoop() {
-        moveSnake();
-        checkCollision();
-        
-        if (!isGameOver) {
-            drawSnake();
-            checkFood();
-        }
+  }
+
+  // Initialize the game
+  function initGame() {
+    // Reset game state
+    snake = [];
+    direction = "right";
+    nextDirection = "right";
+    score = 0;
+    isGameOver = false;
+
+    // Clear the game board
+    gameBoard.innerHTML = "";
+    gameBoard.style.gridTemplateColumns = `repeat(${GRID_SIZE}, 1fr)`;
+    gameBoard.style.gridTemplateRows = `repeat(${GRID_SIZE}, 1fr)`;
+
+    // Create the grid cells
+    for (let i = 0; i < GRID_SIZE * GRID_SIZE; i++) {
+      const cell = document.createElement("div");
+      cell.classList.add("cell");
+      gameBoard.appendChild(cell);
     }
-    
-    // Move the snake
-    function moveSnake() {
-        // Update direction
-        direction = nextDirection;
-        
-        // Calculate new head position
-        const head = { ...snake[0] };
-        
-        switch (direction) {
-            case 'up':
-                head.y--;
-                break;
-            case 'down':
-                head.y++;
-                break;
-            case 'left':
-                head.x--;
-                break;
-            case 'right':
-                head.x++;
-                break;
-        }
-        
-        // Add new head to the beginning of the snake
-        snake.unshift(head);
-        
-        // Remove the tail unless the snake ate food
-        if (head.x !== food.x || head.y !== food.y) {
-            snake.pop();
-        } else {
-            // Snake ate food, place new food and update score
-            placeFood();
-            score += 10;
-            updateScore();
-            
-            // Speed up the game slightly
-            if (gameInterval) {
-                clearInterval(gameInterval);
-                const newSpeed = Math.max(GAME_SPEED - Math.floor(score / 50) * 5, 70);
-                gameInterval = setInterval(gameLoop, newSpeed);
-            }
-        }
+
+    // Initialize the snake
+    const startX = Math.floor(GRID_SIZE / 2);
+    const startY = Math.floor(GRID_SIZE / 2);
+
+    for (let i = 0; i < INITIAL_SNAKE_LENGTH; i++) {
+      snake.push({
+        x: startX - i,
+        y: startY,
+      });
     }
-    
-    // Check for collisions
-    function checkCollision() {
-        const head = snake[0];
-        
-        // Check wall collision
-        if (
-            head.x < 0 || 
-            head.x >= GRID_SIZE || 
-            head.y < 0 || 
-            head.y >= GRID_SIZE
-        ) {
-            gameOver();
-            return;
-        }
-        
-        // Check self collision (starting from index 1 to skip the head)
-        for (let i = 1; i < snake.length; i++) {
-            if (head.x === snake[i].x && head.y === snake[i].y) {
-                gameOver();
-                return;
-            }
-        }
-    }
-    
-    // Check if snake ate food
-    function checkFood() {
-        const head = snake[0];
-        
-        if (head.x === food.x && head.y === food.y) {
-            // Play eating sound effect
-            playEatingSound();
-        }
-    }
-    
-    // Draw the snake on the board
-    function drawSnake() {
-        // Clear all snake cells
-        const cells = document.querySelectorAll('.snake-cell, .food-cell');
-        cells.forEach(cell => {
-            cell.classList.remove('snake-cell', 'snake-head', 'food-cell');
-        });
-        
-        // Draw snake
-        snake.forEach((segment, index) => {
-            if (segment.x >= 0 && segment.x < GRID_SIZE && segment.y >= 0 && segment.y < GRID_SIZE) {
-                const cellIndex = segment.y * GRID_SIZE + segment.x;
-                const cell = gameBoard.children[cellIndex];
-                
-                if (cell) {
-                    cell.classList.add('snake-cell');
-                    
-                    // Add special class for the head
-                    if (index === 0) {
-                        cell.classList.add('snake-head');
-                    }
-                }
-            }
-        });
-        
-        // Draw food
-        if (food.x >= 0 && food.x < GRID_SIZE && food.y >= 0 && food.y < GRID_SIZE) {
-            const foodIndex = food.y * GRID_SIZE + food.x;
-            const foodCell = gameBoard.children[foodIndex];
-            
-            if (foodCell) {
-                foodCell.classList.add('food-cell');
-            }
-        }
-    }
-    
-    // Place food at a random empty position
-    function placeFood() {
-        const emptyCells = [];
-        
-        // Find all empty cells
-        for (let y = 0; y < GRID_SIZE; y++) {
-            for (let x = 0; x < GRID_SIZE; x++) {
-                // Check if this cell is occupied by the snake
-                let isOccupied = false;
-                
-                for (const segment of snake) {
-                    if (segment.x === x && segment.y === y) {
-                        isOccupied = true;
-                        break;
-                    }
-                }
-                
-                if (!isOccupied) {
-                    emptyCells.push({ x, y });
-                }
-            }
-        }
-        
-        // Randomly select an empty cell
-        if (emptyCells.length > 0) {
-            const randomIndex = Math.floor(Math.random() * emptyCells.length);
-            food = emptyCells[randomIndex];
-        }
-    }
-    
+
+    // Draw the initial snake
+    drawSnake();
+
+    // Place the first food
+    placeFood();
+
     // Update the score display
-    function updateScore() {
-        scoreElement.textContent = score;
-        finalScoreElement.textContent = score;
+    updateScore();
+
+    // Hide game over screen
+    gameOverElement.classList.remove("show");
+
+    // Start the game loop
+    if (gameInterval) clearInterval(gameInterval);
+    gameInterval = setInterval(gameLoop, GAME_SPEED);
+  }
+
+  // Main game loop
+  function gameLoop() {
+    moveSnake();
+    checkCollision();
+
+    if (!isGameOver) {
+      drawSnake();
+      checkFood();
     }
-    
-    // Game over
-    function gameOver() {
-        isGameOver = true;
+  }
+
+  // Move the snake
+  function moveSnake() {
+    // Update direction
+    direction = nextDirection;
+
+    // Calculate new head position
+    const head = { ...snake[0] };
+
+    switch (direction) {
+      case "up":
+        head.y--;
+        break;
+      case "down":
+        head.y++;
+        break;
+      case "left":
+        head.x--;
+        break;
+      case "right":
+        head.x++;
+        break;
+    }
+
+    // Add new head to the beginning of the snake
+    snake.unshift(head);
+
+    // Remove the tail unless the snake ate food
+    if (head.x !== food.x || head.y !== food.y) {
+      snake.pop();
+    } else {
+      // Snake ate food, place new food and update score
+      placeFood();
+      score += 10;
+      updateScore();
+
+      // Speed up the game slightly
+      if (gameInterval) {
         clearInterval(gameInterval);
-        gameOverElement.classList.add('show');
-        playGameOverSound();
+        const newSpeed = Math.max(GAME_SPEED - Math.floor(score / 50) * 5, 70);
+        gameInterval = setInterval(gameLoop, newSpeed);
+      }
     }
-    
-    // Sound effects
-    function playEatingSound() {
-        // Simple audio feedback using Web Audio API
-        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        const oscillator = audioContext.createOscillator();
-        const gainNode = audioContext.createGain();
-        
-        oscillator.type = 'sine';
-        oscillator.frequency.setValueAtTime(880, audioContext.currentTime);
-        oscillator.frequency.exponentialRampToValueAtTime(440, audioContext.currentTime + 0.1);
-        
-        gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
-        gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.1);
-        
-        oscillator.connect(gainNode);
-        gainNode.connect(audioContext.destination);
-        
-        oscillator.start();
-        oscillator.stop(audioContext.currentTime + 0.1);
+  }
+
+  // Check for collisions
+  function checkCollision() {
+    const head = snake[0];
+
+    // Check wall collision
+    if (
+      head.x < 0 ||
+      head.x >= GRID_SIZE ||
+      head.y < 0 ||
+      head.y >= GRID_SIZE
+    ) {
+      gameOver();
+      return;
     }
-    
-    function playGameOverSound() {
-        // Game over sound effect
-        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        const oscillator = audioContext.createOscillator();
-        const gainNode = audioContext.createGain();
-        
-        oscillator.type = 'sawtooth';
-        oscillator.frequency.setValueAtTime(220, audioContext.currentTime);
-        oscillator.frequency.exponentialRampToValueAtTime(110, audioContext.currentTime + 0.5);
-        
-        gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
-        gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.5);
-        
-        oscillator.connect(gainNode);
-        gainNode.connect(audioContext.destination);
-        
-        oscillator.start();
-        oscillator.stop(audioContext.currentTime + 0.5);
+
+    // Check self collision (starting from index 1 to skip the head)
+    for (let i = 1; i < snake.length; i++) {
+      if (head.x === snake[i].x && head.y === snake[i].y) {
+        gameOver();
+        return;
+      }
     }
-    
-    // Event listeners for keyboard controls
-    document.addEventListener('keydown', (e) => {
-        switch (e.key) {
-            case 'ArrowUp':
-                if (direction !== 'down') nextDirection = 'up';
-                e.preventDefault();
-                break;
-            case 'ArrowDown':
-                if (direction !== 'up') nextDirection = 'down';
-                e.preventDefault();
-                break;
-            case 'ArrowLeft':
-                if (direction !== 'right') nextDirection = 'left';
-                e.preventDefault();
-                break;
-            case 'ArrowRight':
-                if (direction !== 'left') nextDirection = 'right';
-                e.preventDefault();
-                break;
+  }
+
+  // Check if snake ate food
+  function checkFood() {
+    const head = snake[0];
+
+    if (head.x === food.x && head.y === food.y) {
+      // Play eating sound effect
+      playEatingSound();
+    }
+  }
+
+  // Draw the snake on the board
+  function drawSnake() {
+    // Clear all snake cells
+    const cells = document.querySelectorAll(".snake-cell, .food-cell");
+    cells.forEach((cell) => {
+      cell.classList.remove("snake-cell", "snake-head", "food-cell");
+    });
+
+    // Draw snake
+    snake.forEach((segment, index) => {
+      if (
+        segment.x >= 0 &&
+        segment.x < GRID_SIZE &&
+        segment.y >= 0 &&
+        segment.y < GRID_SIZE
+      ) {
+        const cellIndex = segment.y * GRID_SIZE + segment.x;
+        const cell = gameBoard.children[cellIndex];
+
+        if (cell) {
+          cell.classList.add("snake-cell");
+
+          // Add special class for the head
+          if (index === 0) {
+            cell.classList.add("snake-head");
+          }
         }
+      }
     });
-    
-    // Event listeners for touch controls
-    upBtn.addEventListener('click', () => {
-        if (direction !== 'down') nextDirection = 'up';
-    });
-    
-    downBtn.addEventListener('click', () => {
-        if (direction !== 'up') nextDirection = 'down';
-    });
-    
-    leftBtn.addEventListener('click', () => {
-        if (direction !== 'right') nextDirection = 'left';
-    });
-    
-    rightBtn.addEventListener('click', () => {
-        if (direction !== 'left') nextDirection = 'right';
-    });
-    
-    // Event listener for restart button
-    restartBtn.addEventListener('click', initGame);
-    
-    // Initialize the game when the page loads
-    initGame();
+
+    // Draw food
+    if (
+      food.x >= 0 &&
+      food.x < GRID_SIZE &&
+      food.y >= 0 &&
+      food.y < GRID_SIZE
+    ) {
+      const foodIndex = food.y * GRID_SIZE + food.x;
+      const foodCell = gameBoard.children[foodIndex];
+
+      if (foodCell) {
+        foodCell.classList.add("food-cell");
+      }
+    }
+  }
+
+  // Place food at a random empty position
+  function placeFood() {
+    const emptyCells = [];
+
+    // Find all empty cells
+    for (let y = 0; y < GRID_SIZE; y++) {
+      for (let x = 0; x < GRID_SIZE; x++) {
+        // Check if this cell is occupied by the snake
+        let isOccupied = false;
+
+        for (const segment of snake) {
+          if (segment.x === x && segment.y === y) {
+            isOccupied = true;
+            break;
+          }
+        }
+
+        if (!isOccupied) {
+          emptyCells.push({ x, y });
+        }
+      }
+    }
+
+    // Randomly select an empty cell
+    if (emptyCells.length > 0) {
+      const randomIndex = Math.floor(Math.random() * emptyCells.length);
+      food = emptyCells[randomIndex];
+    }
+  }
+
+  // Update the score display
+  function updateScore() {
+    scoreElement.textContent = score;
+    finalScoreElement.textContent = score;
+  }
+
+  // Game over
+  function gameOver() {
+    isGameOver = true;
+    clearInterval(gameInterval);
+    gameOverElement.classList.add("show");
+    playGameOverSound();
+  }
+
+  // Sound effects
+  function playEatingSound() {
+    // Simple audio feedback using Web Audio API
+    const audioContext = new (window.AudioContext ||
+      window.webkitAudioContext)();
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+
+    oscillator.type = "sine";
+    oscillator.frequency.setValueAtTime(880, audioContext.currentTime);
+    oscillator.frequency.exponentialRampToValueAtTime(
+      440,
+      audioContext.currentTime + 0.1,
+    );
+
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(
+      0.01,
+      audioContext.currentTime + 0.1,
+    );
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    oscillator.start();
+    oscillator.stop(audioContext.currentTime + 0.1);
+  }
+
+  function playGameOverSound() {
+    // Game over sound effect
+    const audioContext = new (window.AudioContext ||
+      window.webkitAudioContext)();
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+
+    oscillator.type = "sawtooth";
+    oscillator.frequency.setValueAtTime(220, audioContext.currentTime);
+    oscillator.frequency.exponentialRampToValueAtTime(
+      110,
+      audioContext.currentTime + 0.5,
+    );
+
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(
+      0.01,
+      audioContext.currentTime + 0.5,
+    );
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    oscillator.start();
+    oscillator.stop(audioContext.currentTime + 0.5);
+  }
+
+  // Event listeners for keyboard controls
+  document.addEventListener("keydown", (e) => {
+    switch (e.key) {
+      case "ArrowUp":
+        if (direction !== "down") nextDirection = "up";
+        e.preventDefault();
+        break;
+      case "ArrowDown":
+        if (direction !== "up") nextDirection = "down";
+        e.preventDefault();
+        break;
+      case "ArrowLeft":
+        if (direction !== "right") nextDirection = "left";
+        e.preventDefault();
+        break;
+      case "ArrowRight":
+        if (direction !== "left") nextDirection = "right";
+        e.preventDefault();
+        break;
+      case " ":
+        if (!isGameRunning) startGame();
+        e.preventDefault();
+        break;
+    }
+  });
+
+  // Event listeners for touch controls
+  upBtn.addEventListener("click", () => {
+    if (direction !== "down") nextDirection = "up";
+  });
+
+  downBtn.addEventListener("click", () => {
+    if (direction !== "up") nextDirection = "down";
+  });
+
+  leftBtn.addEventListener("click", () => {
+    if (direction !== "right") nextDirection = "left";
+  });
+
+  rightBtn.addEventListener("click", () => {
+    if (direction !== "left") nextDirection = "right";
+  });
+
+  // Event listener for restart button
+  restartBtn.addEventListener("click", initGame);
+
+  // Event listerner fot start game
+  startScreen.addEventListener("click", () => {
+    if (!isGameRunning) startGame();
+  });
 });
+

--- a/style.css
+++ b/style.css
@@ -1,201 +1,233 @@
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    font-family: 'Arial', sans-serif;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: "Arial", sans-serif;
 }
 
 body {
-    background-color: #121212;
-    color: #ffffff;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    overflow: hidden;
+  background-color: #121212;
+  color: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  overflow: hidden;
 }
 
 .game-container {
-    width: 100%;
-    max-width: 500px;
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
+  width: 100%;
+  max-width: 500px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 }
 
 .game-header {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 h1 {
-    font-size: 2rem;
-    color: #4ade80;
-    text-shadow: 0 0 10px rgba(74, 222, 128, 0.5);
+  font-size: 2rem;
+  color: #4ade80;
+  text-shadow: 0 0 10px rgba(74, 222, 128, 0.5);
 }
 
 .score-container {
-    font-size: 1.2rem;
-    background-color: #1e1e1e;
-    padding: 8px 16px;
-    border-radius: 20px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  font-size: 1.2rem;
+  background-color: #1e1e1e;
+  padding: 8px 16px;
+  border-radius: 20px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
 }
 
 #score {
-    color: #4ade80;
-    font-weight: bold;
+  color: #4ade80;
+  font-weight: bold;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+}
+
+.overlay.show {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.overlay p {
+  font-size: 1.8rem;
+  color: #4ade80;
+  text-shadow: 0 0 10px rgba(74, 222, 128, 0.5);
+  text-align: center;
+  padding: 0 20px;
 }
 
 .game-board {
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    background-color: #1e1e1e;
-    border-radius: 8px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-    position: relative;
-    overflow: hidden;
-    display: grid;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background-color: #1e1e1e;
+  border-radius: 8px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+  position: relative;
+  overflow: hidden;
+  display: grid;
 }
 
 .snake-cell {
-    background-color: #4ade80;
-    border-radius: 4px;
-    margin: 1px;
-    box-shadow: 0 0 5px rgba(74, 222, 128, 0.5);
+  background-color: #4ade80;
+  border-radius: 4px;
+  margin: 1px;
+  box-shadow: 0 0 5px rgba(74, 222, 128, 0.5);
 }
 
 .snake-head {
-    background-color: #22c55e;
-    box-shadow: 0 0 8px rgba(34, 197, 94, 0.7);
+  background-color: #22c55e;
+  box-shadow: 0 0 8px rgba(34, 197, 94, 0.7);
 }
 
 .food-cell {
-    background-color: #f87171;
-    border-radius: 50%;
-    margin: 3px;
-    box-shadow: 0 0 8px rgba(248, 113, 113, 0.7);
-    animation: pulse 1s infinite alternate;
+  background-color: #f87171;
+  border-radius: 50%;
+  margin: 3px;
+  box-shadow: 0 0 8px rgba(248, 113, 113, 0.7);
+  animation: pulse 1s infinite alternate;
 }
 
 @keyframes pulse {
-    from {
-        transform: scale(0.9);
-    }
-    to {
-        transform: scale(1.1);
-    }
+  from {
+    transform: scale(0.9);
+  }
+  to {
+    transform: scale(1.1);
+  }
 }
 
 .controls {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
 }
 
 .controls-row {
-    display: flex;
-    justify-content: center;
-    gap: 10px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
 }
 
 button {
-    background-color: #2d2d2d;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 12px 20px;
-    font-size: 1.2rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    min-width: 50px;
+  background-color: #2d2d2d;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 20px;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 50px;
 }
 
 button:hover {
-    background-color: #3d3d3d;
-    transform: translateY(-2px);
+  background-color: #3d3d3d;
+  transform: translateY(-2px);
 }
 
 button:active {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 #restart-btn {
-    background-color: #4ade80;
-    color: #121212;
-    font-weight: bold;
-    padding: 12px 24px;
-    font-size: 1.1rem;
-    margin-top: 20px;
+  background-color: #4ade80;
+  color: #121212;
+  font-weight: bold;
+  padding: 12px 24px;
+  font-size: 1.1rem;
+  margin-top: 20px;
 }
 
 #restart-btn:hover {
-    background-color: #22c55e;
+  background-color: #22c55e;
 }
 
 .game-over {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.8);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 10;
-    backdrop-filter: blur(5px);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  backdrop-filter: blur(5px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
 }
 
 .game-over.show {
-    opacity: 1;
-    pointer-events: all;
+  opacity: 1;
+  pointer-events: all;
 }
 
 .game-over h2 {
-    font-size: 2.5rem;
-    color: #f87171;
-    margin-bottom: 20px;
-    text-shadow: 0 0 10px rgba(248, 113, 113, 0.5);
+  font-size: 2.5rem;
+  color: #f87171;
+  margin-bottom: 20px;
+  text-shadow: 0 0 10px rgba(248, 113, 113, 0.5);
 }
 
 .game-over p {
-    font-size: 1.2rem;
-    margin-bottom: 10px;
+  font-size: 1.2rem;
+  margin-bottom: 10px;
 }
 
 #final-score {
-    color: #4ade80;
-    font-weight: bold;
-    font-size: 1.5rem;
+  color: #4ade80;
+  font-weight: bold;
+  font-size: 1.5rem;
 }
 
 @media (min-width: 768px) {
-    .controls {
-        display: none;
-    }
+  .controls {
+    display: none;
+  }
 }
 
 @media (max-width: 767px) {
-    .game-container {
-        padding: 10px;
-    }
-    
-    h1 {
-        font-size: 1.5rem;
-    }
-    
-    .score-container {
-        font-size: 1rem;
-        padding: 6px 12px;
-    }
+  .game-container {
+    padding: 10px;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+  }
+
+  .score-container {
+    font-size: 1rem;
+    padding: 6px 12px;
+  }
 }
+


### PR DESCRIPTION
Closes #1 

### What

- Added a start screen overlay that displays a message prompting the user to start the game.
- Prevented the game loop from starting automatically on page load.
- The game now starts only after the user presses Space, or clicks the overlay.
- Added CSS styles for the start screen to match the existing game over overlay.
- Fixed a minor bug in keyboard event handling (missing break statement).

### Why

This improves the user experience by giving control to players to start the game when they're ready, avoiding confusion caused by the game starting automatically.

### How to test

1. Load the game and verify the start screen appears.
2. Confirm the game doesn't start until you press Space, or click the overlay.
3. Play the game and verify normal functionality.